### PR TITLE
WMS-529 | Fix text-ellipsizable for text updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paack-ui-assets",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "",
   "files": [
     "js"

--- a/src/js/ellipsizableText.js
+++ b/src/js/ellipsizableText.js
@@ -82,11 +82,20 @@ class EllipsizableText extends HTMLElement {
 
     this.textNode.textContent = textContent;
 
-    runDelayed(this.addTooltip.bind(this));
+    runDelayed(this.updateTooltip.bind(this));
   }
 
-  addTooltip () {
-    if (this.textNode.offsetWidth < this.textNode.scrollWidth) {
+  updateTooltip () {
+    const isOverflowing = this.textNode.offsetWidth < this.textNode.scrollWidth
+    const existingTooltip = this.getExistingTooltip()
+
+    if (existingTooltip && !isOverflowing) {
+      this.shadowRoot.removeChild(existingTooltip)
+      this.textNode.removeAttribute('tabIndex');
+      this.textNode.classList.remove('text--overflown');
+    }
+
+    if (!existingTooltip && isOverflowing) {
       this.textNode.setAttribute('tabIndex', 0);
       this.textNode.classList.add('text--overflown');
 
@@ -99,10 +108,14 @@ class EllipsizableText extends HTMLElement {
     }
   }
 
+  getExistingTooltip () {
+    return this.shadowRoot.querySelector('.tooltip')
+  }
+
   attributeChangedCallback(attrName, oldVal, newVal) {
     if (attrName === TEXT_ATTRIBUTE && oldVal !== null) {
       this.textNode.textContent = newVal;
-      this.addTooltip()
+      this.updateTooltip()
     }
   }
 }

--- a/src/js/ellipsizableText.js
+++ b/src/js/ellipsizableText.js
@@ -65,7 +65,7 @@ const template = Object.assign(document.createElement('template'), {
 
 const runDelayed = window.requestIdleCallback || window.requestAnimationFrame;
 
-const TEXT_ATTRIBUTE = 'text'
+const TEXT_ATTRIBUTE = 'text';
 
 class EllipsizableText extends HTMLElement {
   constructor() {
@@ -86,11 +86,11 @@ class EllipsizableText extends HTMLElement {
   }
 
   updateTooltip () {
-    const isOverflowing = this.textNode.offsetWidth < this.textNode.scrollWidth
-    const existingTooltip = this.getExistingTooltip()
+    const isOverflowing = this.textNode.offsetWidth < this.textNode.scrollWidth;
+    const existingTooltip = this.getExistingTooltip();
 
     if (existingTooltip && !isOverflowing) {
-      this.shadowRoot.removeChild(existingTooltip)
+      this.shadowRoot.removeChild(existingTooltip);
       this.textNode.removeAttribute('tabIndex');
       this.textNode.classList.remove('text--overflown');
     }
@@ -109,13 +109,13 @@ class EllipsizableText extends HTMLElement {
   }
 
   getExistingTooltip () {
-    return this.shadowRoot.querySelector('.tooltip')
+    return this.shadowRoot.querySelector('.tooltip');
   }
 
   attributeChangedCallback(attrName, oldVal, newVal) {
     if (attrName === TEXT_ATTRIBUTE && oldVal !== null) {
       this.textNode.textContent = newVal;
-      this.updateTooltip()
+      this.updateTooltip();
     }
   }
 }


### PR DESCRIPTION
`text-ellipsizable` was working fine for first renders, but it wasn't handling updates, which was resulting in scenarios like this

![bug](https://user-images.githubusercontent.com/6733537/92406510-a1f42b00-f151-11ea-88d6-4df6958422c6.png)

In this screenshot, you can see that `textContent` of `span.text` are different from that of `ellipsizable-text`, this was causing the table filters to behave buggy. Changes here are an attempt to fix it.
