### PR TITLE
WS-351 | Fix scrollbar flicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paack-ui-assets",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "",
   "files": [
     "js"

--- a/src/js/ellipsizableText.js
+++ b/src/js/ellipsizableText.js
@@ -24,7 +24,6 @@ const template = Object.assign(document.createElement('template'), {
           box-sizing: content-box;
           left: -12px;
           opacity: 0;
-          width: 0;
           clip: rect(0, 0, 0, 0);
           word-break: break-all;
         }


### PR DESCRIPTION
For some reason this line makes the event history table in WMS's package lookup screen fill more space when its ellipsis tooltip is hidden.

This is messing with the vertical space occupied by that table and making the screen flicker, removing this line fixes that without breaking any layout.